### PR TITLE
Slack Notification for Nightly status change

### DIFF
--- a/art-bot.py
+++ b/art-bot.py
@@ -49,6 +49,7 @@ _*ART releases:*_
 * Which build of `image_name` is in `release image name or pullspec`?
 * What (commits|catalogs|distgits|nvrs|images) are associated with `release-tag`?
 * Image list advisory `advisory_id`
+* Alert if `release_url` (stops being blue|fails|is rejected|is red|is accepted|is green)
 
 _*ART build info:*_
 * Where in `major.minor` (is|are) the `name1,name2,...` (RPM|package) used?
@@ -280,7 +281,7 @@ def respond(client: RTMClient, event: dict):
 
             # Others
             {
-                'regex': r'^Alert if https://(?P<release_browser>[\w]+).ocp.releases.ci.openshift.org(?P<nightly_url>[\w/.-]+) stops being blue$',
+                'regex': r'^Alert if https://(?P<release_browser>[\w]+).ocp.releases.ci.openshift.org(?P<release_url>[\w/.-]+) (stops being blue|fails|is rejected|is red|is accepted|is green)$',
                 'flag': re.I,
                 'function': nightly_color_status,
                 'user_id': True

--- a/art-bot.py
+++ b/art-bot.py
@@ -22,6 +22,7 @@ from artbotlib.slack_output import SlackOutput
 from artbotlib import brew_list, elliott
 from artbotlib.pipeline_image_names import pipeline_from_distgit, pipeline_from_github, pipeline_from_brew, \
     pipeline_from_cdn, pipeline_from_delivery
+from artbotlib.nightly_color import nightly_color_status
 
 logger = logging.getLogger()
 
@@ -275,14 +276,24 @@ def respond(client: RTMClient, event: dict):
                 'regex': r'^.*(image )?pipeline \s*for \s*image \s*(registry.redhat.io/)*(openshift4/)*(?P<delivery_repo_name>[a-zA-Z0-9-]+)\s*( \s*in \s*(?P<version>\d+.\d+))?\s*$',
                 'flag': re.I,
                 'function': pipeline_from_delivery
-            }
+            },
 
+            # Others
+            {
+                'regex': r'^Alert if https://(?P<release_browser>[\w]+).ocp.releases.ci.openshift.org(?P<nightly_url>[\w/.-]+) stops being blue$',
+                'flag': re.I,
+                'function': nightly_color_status,
+                'user_id': True
+            }
         ]
 
         for r in regex_maps:
             m = re.match(r['regex'], plain_text, r['flag'])
             if m:
-                r['function'](so, **m.groupdict())
+                if r.get('user_id', False):  # if functions need to cc the user
+                    r['function'](so, user_id, **m.groupdict())
+                else:
+                    r['function'](so, **m.groupdict())
 
         if not so.said_something:
             so.say("Sorry, I can't help with that yet. Ask 'help' to see what I can do.")
@@ -353,7 +364,7 @@ def consumer_thread(client_id, topic, callback_handler, consumer, durable, user_
 
 @click.command()
 def run():
-
+    
     try:
         config_file = os.environ.get("ART_BOT_SETTINGS_YAML", f"{os.environ['HOME']}/.config/art-bot/settings.yaml")
         with open(config_file, 'r') as stream:

--- a/art-bot.py
+++ b/art-bot.py
@@ -281,7 +281,7 @@ def respond(client: RTMClient, event: dict):
 
             # Others
             {
-                'regex': r'^Alert if https://(?P<release_browser>[\w]+).ocp.releases.ci.openshift.org(?P<release_url>[\w/.-]+) (stops being blue|fails|is rejected|is red|is accepted|is green)$',
+                'regex': r'^Alert ?(if|when|on)? https://(?P<release_browser>[\w]+).ocp.releases.ci.openshift.org(?P<release_url>[\w/.-]+) ?(stops being blue|fails|is rejected|is red|is accepted|is green)?$',
                 'flag': re.I,
                 'function': nightly_color_status,
                 'user_id': True

--- a/artbotlib/nightly_color.py
+++ b/artbotlib/nightly_color.py
@@ -7,6 +7,9 @@ COLOR_MAPS = {
     'Rejected': 'Red'
 }
 
+TWELVE_HOURS = 60 * 60 * 12
+FIVE_MINUTES = 60 * 5
+
 
 def get_nightly_color(nightly_url, release_browser) -> Union[str, None]:
     """
@@ -41,11 +44,11 @@ def nightly_color_status(so, user_id, nightly_url, release_browser) -> None:
         start = time.time()
         while True:
             now = time.time()
-            if now - start > 43200:  # Timeout after 12 hrs.
+            if now - start > TWELVE_HOURS:  # Timeout after 12 hrs.
                 so.say(f"<@{user_id}> Color didn't change even after 12 hrs :(")
                 break
 
-            time.sleep(300)  # check every 5 minutes
+            time.sleep(FIVE_MINUTES)  # check every 5 minutes
 
             color = get_nightly_color(nightly_url, release_browser)
             if color:

--- a/artbotlib/nightly_color.py
+++ b/artbotlib/nightly_color.py
@@ -1,0 +1,62 @@
+import requests
+from bs4 import BeautifulSoup
+import time
+from typing import Union
+
+COLOR_MAPS = {
+    'text-danger': 'Red',
+    'text-success': 'Green'
+}
+
+
+def get_nightly_color(nightly_url, release_browser) -> Union[str, None]:
+    """
+    Function to get the color of the nightly for the given release browser
+    :param nightly_url: URL of the nightly eg: /releasestream/4.10.0-0.nightly/release/4.10.0-0.nightly-2022-07-13-131411
+    :param release_browser: release browser eg: ppc64le/arm64/s390x/amd64
+    :return:
+    """
+    url = f"https://{release_browser}.ocp.releases.ci.openshift.org"
+    response = requests.get(url)  # get the webpage
+
+    data = response.content.decode()
+    soup = BeautifulSoup(data, "html.parser")  # parse html
+    for content in soup.find_all("a"):
+        if content.attrs['href'] == nightly_url:
+            color = content.attrs['class']
+            if color:  # If color is empty, it means its blue
+                return color.pop()
+            return None
+
+
+def nightly_color_status(so, user_id, nightly_url, release_browser) -> None:
+    """
+    Driver function to provide slack update if color of nightly changes from blue to green/red
+    :param so: Slack object
+    :param user_id: User ID of the person who invoked ART-Bot
+    :param nightly_url: URL of the nightly eg: /releasestream/4.10.0-0.nightly/release/4.10.0-0.nightly-2022-07-13-131411
+    :param release_browser: release browser eg: ppc64le/arm64/s390x/amd64
+    :return: None
+    """
+    try:
+        color = get_nightly_color(nightly_url, release_browser)
+        if color:  # if color is not blue return the current color and exit
+            so.say(f"<@{user_id}> Color of nightly is already `{COLOR_MAPS[color]}`")
+            return
+
+        so.say(f"<@{user_id}> Ok, I'll respond here when tests have finished.")
+        start = time.time()
+        while True:
+            now = time.time()
+            if now - start > 43200:  # Timeout after 12 hrs.
+                so.say(f"<@{user_id}> Color didn't change even after 12 hrs :(")
+                break
+
+            time.sleep(300)  # check every 5 minutes
+
+            color = get_nightly_color(nightly_url, release_browser)
+            if color:
+                so.say(f"<@{user_id}> Color changed to `{COLOR_MAPS[color]}`")
+                break
+    except Exception as e:
+        so.say(f"Unexpected Error: {e}")

--- a/artbotlib/nightly_color.py
+++ b/artbotlib/nightly_color.py
@@ -11,31 +11,31 @@ TWELVE_HOURS = 60 * 60 * 12
 FIVE_MINUTES = 60 * 5
 
 
-def get_nightly_color(nightly_url, release_browser) -> Union[str, None]:
+def get_nightly_color(release_url, release_browser) -> Union[str, None]:
     """
     Function to get the color of the nightly for the given release browser
-    :param nightly_url: URL of the nightly eg: /releasestream/4.10.0-0.nightly/release/4.10.0-0.nightly-2022-07-13-131411
+    :param release_url: URL of the nightly/release eg: /releasestream/4.10.0-0.nightly/release/4.10.0-0.nightly-2022-07-13-131411
     :param release_browser: release browser eg: ppc64le/arm64/s390x/amd64
     :return:
     """
-    url = f"https://{release_browser}.ocp.releases.ci.openshift.org/api/v1{nightly_url}"
+    url = f"https://{release_browser}.ocp.releases.ci.openshift.org/api/v1{release_url}"
     response = requests.get(url)  # query API to get the status
 
     status = response.json()['phase']
     return COLOR_MAPS.get(status, None)
 
 
-def nightly_color_status(so, user_id, nightly_url, release_browser) -> None:
+def nightly_color_status(so, user_id, release_url, release_browser) -> None:
     """
     Driver function to provide slack update if color of nightly changes from blue to green/red
     :param so: Slack object
     :param user_id: User ID of the person who invoked ART-Bot
-    :param nightly_url: URL of the nightly eg: /releasestream/4.10.0-0.nightly/release/4.10.0-0.nightly-2022-07-13-131411
+    :param release_url: URL of the nightly eg: /releasestream/4.10.0-0.nightly/release/4.10.0-0.nightly-2022-07-13-131411
     :param release_browser: release browser eg: ppc64le/arm64/s390x/amd64
     :return: None
     """
     try:
-        color = get_nightly_color(nightly_url, release_browser)
+        color = get_nightly_color(release_url, release_browser)
         if color:  # if color is not blue return the current color and exit
             so.say(f"<@{user_id}> Color of nightly is already `{color}`")
             return
@@ -50,9 +50,9 @@ def nightly_color_status(so, user_id, nightly_url, release_browser) -> None:
 
             time.sleep(FIVE_MINUTES)  # check every 5 minutes
 
-            color = get_nightly_color(nightly_url, release_browser)
+            color = get_nightly_color(release_url, release_browser)
             if color:
-                so.say(f"<@{user_id}> Color of {release_browser} nightly {nightly_url.split('/')[-1]} changed to `{color}`!")
+                so.say(f"<@{user_id}> Color of {release_browser} nightly {release_url.split('/')[-1]} changed to `{color}`!")
                 break
     except Exception as e:
         so.say(f"Unexpected Error: {e}")

--- a/artbotlib/nightly_color.py
+++ b/artbotlib/nightly_color.py
@@ -1,6 +1,7 @@
 import requests
 import time
 from typing import Union
+import json
 
 COLOR_MAPS = {
     'Accepted': 'Green',
@@ -11,48 +12,83 @@ TWELVE_HOURS = 60 * 60 * 12
 FIVE_MINUTES = 60 * 5
 
 
-def get_nightly_color(release_url, release_browser) -> Union[str, None]:
+def get_release_data(release_url, release_browser) -> json:
     """
-    Function to get the color of the nightly for the given release browser
+    Function to get the release data from the API
+
     :param release_url: URL of the nightly/release eg: /releasestream/4.10.0-0.nightly/release/4.10.0-0.nightly-2022-07-13-131411
     :param release_browser: release browser eg: ppc64le/arm64/s390x/amd64
-    :return:
+    :return: JSON object
     """
     url = f"https://{release_browser}.ocp.releases.ci.openshift.org/api/v1{release_url}"
     response = requests.get(url)  # query API to get the status
 
-    status = response.json()['phase']
+    return response.json()
+
+
+def get_nightly_color(release_url, release_browser) -> Union[str, None]:
+    """
+    Function to get the color of the nightly for the given release browser
+
+    :param release_url: URL of the nightly/release eg: /releasestream/4.10.0-0.nightly/release/4.10.0-0.nightly-2022-07-13-131411
+    :param release_browser: release browser eg: ppc64le/arm64/s390x/amd64
+    :return: Green/Red/None
+    """
+    status = get_release_data(release_url, release_browser)['phase']
     return COLOR_MAPS.get(status, None)
+
+
+def get_failed_jobs(release_url, release_browser) -> str:
+    """
+    Function to get all the failed jobs
+
+    :param release_url: URL of the nightly/release eg: /releasestream/4.10.0-0.nightly/release/4.10.0-0.nightly-2022-07-13-131411
+    :param release_browser: release browser eg: ppc64le/arm64/s390x/amd64
+    :return: Newline separated strings
+    """
+    status = get_release_data(release_url, release_browser)
+
+    payload = "Jobs that failed:\n"
+    jobs = status['results']['blockingJobs']
+    for job in jobs:
+        if jobs[job]['state'].lower() == "failed":
+            payload += f"<{jobs[job]['url']}|{job}>\n"
+    return payload
 
 
 def nightly_color_status(so, user_id, release_url, release_browser) -> None:
     """
     Driver function to provide slack update if color of nightly changes from blue to green/red
+
     :param so: Slack object
     :param user_id: User ID of the person who invoked ART-Bot
     :param release_url: URL of the nightly eg: /releasestream/4.10.0-0.nightly/release/4.10.0-0.nightly-2022-07-13-131411
     :param release_browser: release browser eg: ppc64le/arm64/s390x/amd64
     :return: None
     """
-    try:
+    slack_url_payload = f"<https://{release_browser}.ocp.releases.ci.openshift.org{release_url}|{release_url.split('/')[-1]}>"
+    color = get_nightly_color(release_url, release_browser)
+    if color:  # if color is not blue return the current color and exit
+        so.say(f"<@{user_id}> {slack_url_payload} is already `{color}` !")
+        if color == "Red":
+            payload = get_failed_jobs(release_url, release_browser)
+            so.say(payload)
+        return
+
+    so.say(f"<@{user_id}> Ok, I'll respond here when tests have finished.")
+    start = time.time()
+    while True:
+        now = time.time()
+        if now - start > TWELVE_HOURS:  # Timeout after 12 hrs.
+            so.say(f"<@{user_id}> {slack_url_payload} didn't change even after 12 hrs :(")
+            break
+
+        time.sleep(FIVE_MINUTES)  # check every 5 minutes
+
         color = get_nightly_color(release_url, release_browser)
-        if color:  # if color is not blue return the current color and exit
-            so.say(f"<@{user_id}> Color of nightly is already `{color}`")
-            return
-
-        so.say(f"<@{user_id}> Ok, I'll respond here when tests have finished.")
-        start = time.time()
-        while True:
-            now = time.time()
-            if now - start > TWELVE_HOURS:  # Timeout after 12 hrs.
-                so.say(f"<@{user_id}> Color didn't change even after 12 hrs :(")
-                break
-
-            time.sleep(FIVE_MINUTES)  # check every 5 minutes
-
-            color = get_nightly_color(release_url, release_browser)
-            if color:
-                so.say(f"<@{user_id}> Color of {release_browser} nightly {release_url.split('/')[-1]} changed to `{color}`!")
-                break
-    except Exception as e:
-        so.say(f"Unexpected Error: {e}")
+        if color:
+            so.say(f"<@{user_id}> {slack_url_payload} changed to `{color}` !")
+            if color == "Red":
+                payload = get_failed_jobs(release_url, release_browser)
+                so.say(payload)
+            break

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ aiohttp>=3.7.3
 requests_kerberos
 PyYAML
 click==8.1.2
-beautifulsoup4
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ aiohttp>=3.7.3
 requests_kerberos
 PyYAML
 click==8.1.2
+beautifulsoup4
+requests


### PR DESCRIPTION
Art-Bot will notify users if a blue nightly changes to green/red.
Usage:
```
@art-bot Alert if https://amd64.ocp.releases.ci.openshift.org/releasestream/4.10.0-0.nightly/release/4.10.0-0.nightly-2022-07-13-131411 stops being blue
ART-Bot: Ok, I'll respond here when tests have finished.
<after a long time>
@ashwin Color of amd64 nightly 4.10.0-0.nightly-2022-07-13-131411 changed to Green!
```
It will keep checking every 5 mins and time out after 12 hrs with a error message.
If the color is already green/red, it will report it and exit