### PR TITLE
update doozer command to use disable-gssapi flag

### DIFF
--- a/artbotlib/brew_list.py
+++ b/artbotlib/brew_list.py
@@ -124,7 +124,7 @@ def latest_images_for_version(so, major_minor):
     so.say(f"Determining images for {major_minor} - this may take a few minutes...")
 
     try:
-        rc, stdout, stderr = util.cmd_assert(so, f"doozer --group openshift-{major_minor} images:print '{{component}}-{{version}}-{{release}}' --show-base --show-non-release --short")
+        rc, stdout, stderr = util.cmd_assert(so, f"doozer --disable-gssapi --group openshift-{major_minor} images:print '{{component}}-{{version}}-{{release}}' --show-base --show-non-release --short")
         if rc:
             raise Exception()
     except Exception:  # convert any exception into generic (cmd_assert already reports details to monitoring)
@@ -337,7 +337,7 @@ def _tags_for_version(major_minor):
 
 def list_images_in_major_minor(so, major, minor):
     major_minor = f'{major}.{minor}'
-    rc, stdout, stderr = util.cmd_assert(so, f'doozer --group openshift-{major_minor} images:print \'{{image_name_short}}\' --show-base --show-non-release --short')
+    rc, stdout, stderr = util.cmd_assert(so, f'doozer --disable-gssapi --group openshift-{major_minor} images:print \'{{image_name_short}}\' --show-base --show-non-release --short')
     if rc:
         util.please_notify_art_team_of_error(so, stderr)
     else:

--- a/artbotlib/pipeline_image_util.py
+++ b/artbotlib/pipeline_image_util.py
@@ -241,7 +241,7 @@ def brew_to_delivery(brew_package_name: str, variant: str) -> str:
 
 @util.cached
 def doozer_brew_distgit(version: str) -> list:
-    output = util.cmd_gather(f"doozer -g openshift-{version} images:print --short '{{component}}: {{name}}'")
+    output = util.cmd_gather(f"doozer --disable-gssapi -g openshift-{version} images:print --short '{{component}}: {{name}}'")
     if "koji.GSSAPIAuthError" in output[2]:
         raise exceptions.KerberosAuthenticationError("Kerberos authentication failed for doozer")
 
@@ -537,7 +537,7 @@ def doozer_github_distgit(version: str) -> list:
 
     :version: OCP version
     """
-    output = util.cmd_gather(f"doozer -g openshift-{version} images:print --short '{{name}}: {{upstream_public}}'")
+    output = util.cmd_gather(f"doozer --disable-gssapi -g openshift-{version} images:print --short '{{name}}: {{upstream_public}}'")
     if "koji.GSSAPIAuthError" in output[2]:
         raise exceptions.KerberosAuthenticationError("Kerberos authentication failed for doozer")
 

--- a/artbotlib/translation.py
+++ b/artbotlib/translation.py
@@ -14,7 +14,7 @@ def translate_names(so, name_type, name, name_type2, major=None, minor=None):
     }[name_type2]
     major_minor = f"{major}.{minor}" if major and minor else "4.5"
 
-    rc, stdout, stderr = util.cmd_gather(f"doozer --group openshift-{major_minor} --images {name} images:print \'{{{query_name}}}\' --show-base --show-non-release --short")
+    rc, stdout, stderr = util.cmd_gather(f"doozer --disable-gssapi --group openshift-{major_minor} --images {name} images:print \'{{{query_name}}}\' --show-base --show-non-release --short")
     if rc:
         so.say(f"Sorry, there is no image dist-git {name} in version {major_minor}.")
     else:


### PR DESCRIPTION
The `--disable-gssapi` flag in doozer does not authenticate, therefore only data that do not require auth can be accessed, which is what we want for ART-bot.