### PR TITLE
nightly_color.py: add support for pending jobs

### DIFF
--- a/artbotlib/nightly_color.py
+++ b/artbotlib/nightly_color.py
@@ -48,10 +48,10 @@ def get_failed_jobs(release_url, release_browser) -> str:
     """
     status = get_release_data(release_url, release_browser)
 
-    payload = "Jobs that failed:\n"
+    payload = "Jobs pending/failed:\n"
     jobs = status['results']['blockingJobs']
     for job in jobs:
-        if jobs[job]['state'].lower() == "failed":
+        if jobs[job]['state'].lower() != "succeeded":
             payload += f"<{jobs[job]['url']}|{job}>\n"
     return payload
 


### PR DESCRIPTION
If a nightly color changed from Blue to Red, the jobs that failed were displayed. If the status was `Pending`, no output was displayed. Changed logic from `state == failed` to `state != succeeded` to display jobs that are failed as well as Pending.