### PR TITLE
kerberos issue fix

### DIFF
--- a/artbotlib/kerberos.py
+++ b/artbotlib/kerberos.py
@@ -1,0 +1,37 @@
+import os
+import time
+import subprocess
+
+
+def update_last_kinit_env_var():
+    """
+    This function performs kinit as and when required.
+    The function expects .aws directory in the project base directory.
+    The .aws directory should have a keytab file by name redhat.keytab.
+    :return: None
+    """
+
+    keytab_file = "/tmp/keytab/keytab"
+    kinit_request = subprocess.Popen(["kinit", "-kt", keytab_file, "ocp-build/buildvm.openshift.eng.bos.redhat.com@IPA.REDHAT.COM"],
+                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, error = kinit_request.communicate()
+    if error:
+        print(error)
+    os.environ["LAST_KINIT_TIME"] = str(int(time.time()))
+
+
+def handle_kinit():
+    """
+    This function tests whether kinit is required. The current policy is to do kinit after
+    every hour.
+    :return: None
+    """
+
+    if "LAST_KINIT_TIME" not in os.environ:
+        update_last_kinit_env_var()
+
+    last_update = os.environ["LAST_KINIT_TIME"]
+    time_now = int(time.time())
+
+    if time_now - int(last_update) >= 3600:
+        update_last_kinit_env_var()

--- a/artbotlib/kerberos.py
+++ b/artbotlib/kerberos.py
@@ -1,13 +1,9 @@
-import os
-import time
 import subprocess
 
 
-def update_last_kinit_env_var():
+def do_kinit():
     """
-    This function performs kinit as and when required.
-    The function expects .aws directory in the project base directory.
-    The .aws directory should have a keytab file by name redhat.keytab.
+    Function performs kinit with the already mounted keytab
     :return: None
     """
 
@@ -16,22 +12,5 @@ def update_last_kinit_env_var():
                                      stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output, error = kinit_request.communicate()
     if error:
-        print(error)
-    os.environ["LAST_KINIT_TIME"] = str(int(time.time()))
+        print(f"Kerberos error: {error}")
 
-
-def handle_kinit():
-    """
-    This function tests whether kinit is required. The current policy is to do kinit after
-    every hour.
-    :return: None
-    """
-
-    if "LAST_KINIT_TIME" not in os.environ:
-        update_last_kinit_env_var()
-
-    last_update = os.environ["LAST_KINIT_TIME"]
-    time_now = int(time.time())
-
-    if time_now - int(last_update) >= 3600:
-        update_last_kinit_env_var()

--- a/artbotlib/pipeline_image_util.py
+++ b/artbotlib/pipeline_image_util.py
@@ -500,7 +500,7 @@ def get_delivery_repo_id(name: str) -> str:
 
 
 # Methods
-@util.update_keytab
+@util.refresh_krb_auth
 def request_with_kerberos(url: str) -> requests.Response():
     # Kerberos authentication
     kerberos_auth = HTTPKerberosAuth(mutual_authentication=OPTIONAL)

--- a/artbotlib/pipeline_image_util.py
+++ b/artbotlib/pipeline_image_util.py
@@ -500,6 +500,7 @@ def get_delivery_repo_id(name: str) -> str:
 
 
 # Methods
+@util.update_keytab
 def request_with_kerberos(url: str) -> requests.Response():
     # Kerberos authentication
     kerberos_auth = HTTPKerberosAuth(mutual_authentication=OPTIONAL)

--- a/artbotlib/util.py
+++ b/artbotlib/util.py
@@ -8,6 +8,8 @@ import shlex
 import subprocess
 from threading import RLock
 import time
+from artbotlib.kerberos import handle_kinit
+import functools
 
 logger = logging.getLogger()
 
@@ -207,4 +209,13 @@ def cached_ttl(func):
     @cachetools.cached(CACHE_TTL, lock=LOCK)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
+    return wrapper
+
+
+def update_keytab(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        handle_kinit()
+        func_ret = func(*args, **kwargs)
+        return func_ret
     return wrapper

--- a/artbotlib/util.py
+++ b/artbotlib/util.py
@@ -8,7 +8,7 @@ import shlex
 import subprocess
 from threading import RLock
 import time
-from artbotlib.kerberos import handle_kinit
+from artbotlib.kerberos import do_kinit
 import functools
 
 logger = logging.getLogger()
@@ -212,10 +212,10 @@ def cached_ttl(func):
     return wrapper
 
 
-def update_keytab(func):
+def refresh_krb_auth(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        handle_kinit()
+        do_kinit()
         func_ret = func(*args, **kwargs)
         return func_ret
     return wrapper

--- a/container/krb5-redhat.conf
+++ b/container/krb5-redhat.conf
@@ -1,15 +1,32 @@
-[realms]
-REDHAT.COM = {
-  kdc = kerberos.corp.redhat.com
-  admin_server = kerberos.corp.redhat.com
-}
-[domain_realm]
-.redhat.com = REDHAT.COM
-redhat.com = REDHAT.COM
 [libdefaults]
-# Workaround for running `kinit` in an unprivileged container
-# by storing krb5 credential cache into a file rather than kernel keyring.
-# See https://blog.tomecek.net/post/kerberos-in-a-container/
-default_ccache_name = FILE:/tmp/krb5cc
-rdns = false
-default_realm = REDHAT.COM
+  default_realm = IPA.REDHAT.COM
+  # default_realm = REDHAT.COM
+  dns_lookup_realm = true
+  dns_lookup_kdc = true
+  rdns = false
+  dns_canonicalize_hostname = fallback
+  ticket_lifetime = 24h
+  forwardable = true
+  udp_preference_limit = 0
+  default_ccache_name = FILE:/tmp/krb5cc
+
+[realms]
+
+    REDHAT.COM = {
+        default_domain = redhat.com
+        dns_lookup_kdc = true
+        master_kdc = kerberos.corp.redhat.com
+        admin_server = kerberos.corp.redhat.com
+    }
+
+    #make sure to save the IPA CA cert
+    #mkdir /etc/ipa && curl -o /etc/ipa/ca.crt https://password.corp.redhat.com/ipa.crt
+    IPA.REDHAT.COM = {
+       pkinit_anchors = FILE:/etc/ipa/ca.crt
+       pkinit_pool = FILE:/etc/ipa/ca.crt
+       default_domain = ipa.redhat.com
+       dns_lookup_kdc = true
+       # Trust tickets issued by legacy realm on this host
+       auth_to_local = RULE:[1:$1@$0](.*@REDHAT\.COM)s/@.*//
+       auth_to_local = DEFAULT
+    }


### PR DESCRIPTION
Art-bot kerberos had an issue in which the keytab could not loaded. Fixed the issue by only reading the credentials from the mounted keytab and doing `kinit`. The new kerberos credentials will be stored at the default location which kerberos will automatically access. Reused functions from art-dash codebase.