### PR TITLE
Make monitoring channel optional

### DIFF
--- a/art-bot.py
+++ b/art-bot.py
@@ -78,11 +78,12 @@ def on_load(client: RTMClient, event: dict):
     try:
         bot_config["self"] = {"id": r.data["user_id"], "name": r.data["user"]}
         if "monitoring_channel" not in bot_config:
-            raise Exception("No monitoring_channel configured.")
-        found = lookup_channel(web_client, bot_config["monitoring_channel"], only_private=True)
-        if not found:
-            raise Exception(f"Invalid monitoring channel configured: {bot_config['monitoring_channel']}")
-        bot_config["monitoring_channel_id"] = found["id"]
+            print("Warning: no monitoring_channel configured.")
+        else:
+            found = lookup_channel(web_client, bot_config["monitoring_channel"], only_private=True)
+            if not found:
+                raise Exception(f"Invalid monitoring channel configured: {bot_config['monitoring_channel']}")
+            bot_config["monitoring_channel_id"] = found["id"]
 
         bot_config.setdefault("friendly_channels", [])
         bot_config["friendly_channel_ids"] = []
@@ -168,7 +169,7 @@ def respond(client: RTMClient, event: dict):
             web_client=web_client,
             event=event,
             target_channel_id=target_channel_id,
-            monitoring_channel_id=bot_config["monitoring_channel_id"],
+            monitoring_channel_id=bot_config.get("monitoring_channel_id", None),
             thread_ts=thread_ts,
             alt_username=alt_username,
         )

--- a/artbotlib/slack_output.py
+++ b/artbotlib/slack_output.py
@@ -43,6 +43,8 @@ class SlackOutput:
         pprint.pprint(r)
 
     def monitoring_say(self, text, **msg_opts):
+        if not self.monitoring_channel_id:
+            return
         try:
             msg = dict(
                 channel=self.monitoring_channel_id,
@@ -56,6 +58,8 @@ class SlackOutput:
             traceback.print_exc()
 
     def monitoring_snippet(self, payload, intro=None, filename=None, filetype=None):
+        if not self.monitoring_channel_id:
+            return
         try:
             print("Called with monitoring payload: {}".format(payload))
             r = self.web_client.files_upload(


### PR DESCRIPTION
A local instance of art-bot can be queried dozens of times to develop, test and debug new features. This can be annoying for those who permanently joined the production monitoring channel, and for the feature developer who's constantly pinged (and possibly notified). This PR proposes a change to make the monitoring channel optional. If it is not configured in the settings, art-bot will just print a warning instead of raising and exception, and will safely bypass monitoring features when responding to a query