### PR TITLE
Handle image query errors

### DIFF
--- a/artbotlib/buildinfo.py
+++ b/artbotlib/buildinfo.py
@@ -29,10 +29,12 @@ async def get_image_info(so, name, release_img) -> Union[Tuple[None, None, None]
         return None, None, None
 
     # Get image pullspec
-    rc, stdout, stderr = await util.cmd_gather_async(f"oc adm release info {release_img_pullspec} --image-for {name}")
+    rc, stdout, stderr = await util.cmd_gather_async(
+        f"oc adm release info {release_img_pullspec} --image-for {name}",
+        check=False
+    )
     if rc:
         so.say(f"Sorry, I wasn't able to query the release image pullspec {release_img_pullspec}.")
-        util.please_notify_art_team_of_error(so, stderr)
         return None, None, None
     pullspec = stdout.strip()
 
@@ -221,7 +223,6 @@ def kernel_info(so, release_img):
     for entry in res:
         if isinstance(entry, ChildProcessError):
             so.say(f"Sorry, I wasn't able to query the release image `{release_img}`.")
-            util.please_notify_art_team_of_error(so, str(entry))
             return
 
         output.append(f'Kernel info for `{entry["name"]}` {entry["pullspec"]}:')


### PR DESCRIPTION
At the moment, if an non existing image/pullspec is provided, art-bot while raise a `ChildProcessError` that is not handled. As a result, the user will not be responded and will not know what happened. 

By setting `check=False`, we let `util.cmd_gather_async` gracefully fail with a non-0 exit code that is checked right away. A user friendly notification is then sent back, avoiding redundant error messages that add no value to the end user