### PR TITLE
Add aler for build status

### DIFF
--- a/art-bot.py
+++ b/art-bot.py
@@ -14,7 +14,7 @@ import threading
 import random
 
 import umb
-from artbotlib.buildinfo import buildinfo_for_release, kernel_info
+from artbotlib.buildinfo import buildinfo_for_release, kernel_info, alert_on_build_complete
 from artbotlib.translation import translate_names
 from artbotlib.util import lookup_channel
 from artbotlib.formatting import extract_plain_text, repeat_in_chunks
@@ -239,6 +239,12 @@ def respond(client: RTMClient, event: dict):
                 'regex': r'^%(wh)s rpms? (?P<rpms>[-\w.,* ]+) (is|are) in image %(nvr)s$' % re_snippets,
                 'flag': re.I,
                 'function': brew_list.specific_rpms_for_image
+            },
+            {
+                'regex': r'^alert ?(if|when|on)? build (?P<build_id>\d+) completes$',
+                'flag': re.I,
+                'function': alert_on_build_complete,
+                'user_id': True
             },
 
             # ART advisory info:

--- a/art-bot.py
+++ b/art-bot.py
@@ -241,7 +241,7 @@ def respond(client: RTMClient, event: dict):
                 'function': brew_list.specific_rpms_for_image
             },
             {
-                'regex': r'^alert ?(if|when|on)? build (?P<build_id>\d+) completes$',
+                'regex': r'^alert ?(if|when|on)? build (?P<build_id>\d+|https\://brewweb.engineering.redhat.com/brew/buildinfo\?buildID=\d+) completes$',
                 'flag': re.I,
                 'function': alert_on_build_complete,
                 'user_id': True

--- a/artbotlib/brew_list.py
+++ b/artbotlib/brew_list.py
@@ -6,8 +6,7 @@ import urllib.request
 import koji
 
 from . import util
-
-RHCOS_BASE_URL = "https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/releases"
+from .constants import RHCOS_BASE_URL
 
 
 @util.cached
@@ -340,7 +339,7 @@ def _rhcos_build_url(major_minor, build_id, arch="x86_64"):
 
 def _rhcos_release_url(major_minor, arch="x86_64"):
     arch_suffix = "" if arch == "x86_64" else f"-{arch}"
-    return f"{RHCOS_BASE_URL}/rhcos-{major_minor}{arch_suffix}"
+    return f"{RHCOS_BASE_URL}/storage/releases/rhcos-{major_minor}{arch_suffix}"
 
 
 def _tags_for_version(major_minor):

--- a/artbotlib/buildinfo.py
+++ b/artbotlib/buildinfo.py
@@ -3,7 +3,7 @@ import json
 import re
 from typing import Tuple, Union
 
-from . import util, brew_list
+from . import util, brew_list, constants
 
 
 async def get_image_info(so, name, release_img) -> Union[Tuple[None, None, None], Tuple[str, str, str]]:
@@ -148,8 +148,8 @@ def rhcos_build_urls(build_id, arch="x86_64"):
 
     suffix = "" if arch in ["x86_64", "amd64"] else f"-{arch}"
 
-    contents = f"https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/contents.html?stream=releases/rhcos-{minor_version}{suffix}&release={build_id}"
-    stream = f"https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/?stream=releases/rhcos-{minor_version}{suffix}&release={build_id}#{build_id}"
+    contents = f"{constants.RHCOS_BASE_URL}/contents.html?stream=releases/rhcos-{minor_version}{suffix}&release={build_id}"
+    stream = f"{constants.RHCOS_BASE_URL}/?stream=releases/rhcos-{minor_version}{suffix}&release={build_id}#{build_id}"
     return contents, stream
 
 
@@ -161,7 +161,7 @@ def brew_build_url(nvr):
         print(f"error searching for image {nvr} components in brew: {e}")
         return None
 
-    return f"https://brewweb.engineering.redhat.com/brew/buildinfo?buildID={build['id']}"
+    return f"{constants.BREW_URL}/buildinfo?buildID={build['id']}"
 
 
 def kernel_info(so, release_img):

--- a/artbotlib/buildinfo.py
+++ b/artbotlib/buildinfo.py
@@ -8,6 +8,7 @@ from enum import Enum
 import koji
 
 from . import util, brew_list, constants
+from .constants import BREW_URL
 
 
 class BuildState(Enum):
@@ -244,6 +245,13 @@ def alert_on_build_complete(so, user_id, build_id):
     so.say(f'Ok <@{user_id}>, I\'ll respond here when the build completes')
     start = time.time()
 
+    try:
+        # Has the build passed in by ID?
+        build_id = int(build_id)
+    except ValueError:\
+        # No, by URL
+        build_id = int(build_id.split('=')[-1])
+
     while True:
         # Timeout after 12 hrs
         if time.time() - start > constants.TWELVE_HOURS:
@@ -252,7 +260,7 @@ def alert_on_build_complete(so, user_id, build_id):
 
         # Retrieve build info
         try:
-            build = util.koji_client_session().getBuild(int(build_id), strict=True)
+            build = util.koji_client_session().getBuild(build_id, strict=True)
             state = BuildState(build['state'])
             print(f'Build {build_id} has state {state.name}')
 

--- a/artbotlib/constants.py
+++ b/artbotlib/constants.py
@@ -1,0 +1,18 @@
+RHCOS_BASE_URL = "https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com"
+
+COLOR_MAPS = {
+    'Accepted': 'Green',
+    'Rejected': 'Red'
+}
+
+TWELVE_HOURS = 60 * 60 * 12
+
+FIVE_MINUTES = 60 * 5
+
+BREW_URL = 'https://brewweb.engineering.redhat.com/brew'
+
+CGIT_URL = 'https://pkgs.devel.redhat.com/cgit'
+
+COMET_URL = 'https://comet.engineering.redhat.com/containers/repositories'
+
+ERRATA_TOOL_URL = 'https://errata.devel.redhat.com'

--- a/artbotlib/nightly_color.py
+++ b/artbotlib/nightly_color.py
@@ -3,13 +3,7 @@ import time
 from typing import Union
 import json
 
-COLOR_MAPS = {
-    'Accepted': 'Green',
-    'Rejected': 'Red'
-}
-
-TWELVE_HOURS = 60 * 60 * 12
-FIVE_MINUTES = 60 * 5
+from artbotlib.constants import COLOR_MAPS, TWELVE_HOURS, FIVE_MINUTES
 
 
 def get_release_data(release_url, release_browser) -> json:

--- a/artbotlib/pipeline_image_names.py
+++ b/artbotlib/pipeline_image_names.py
@@ -1,4 +1,4 @@
-from artbotlib import exceptions
+from artbotlib import exceptions, constants
 from artbotlib import pipeline_image_util
 
 
@@ -43,7 +43,7 @@ def pipeline_from_github(so, github_repo, version):
             if len(distgit_repos) > 1:
                 payload += f"\n*More than one dist-gits were found for the GitHub repo `{github_repo}`*\n\n"
             for distgit_repo_name in distgit_repos:
-                payload += f"Production dist-git repo: <https://pkgs.devel.redhat.com/cgit/containers/{distgit_repo_name}|*{distgit_repo_name}*>\n"
+                payload += f"Production dist-git repo: <{constants.CGIT_URL}/containers/{distgit_repo_name}|*{distgit_repo_name}*>\n"
 
                 # Distgit -> Delivery
                 payload += pipeline_image_util.distgit_to_delivery(distgit_repo_name, version, variant)
@@ -99,7 +99,7 @@ def pipeline_from_distgit(so, distgit_repo_name, version):
             payload += f"Private GitHub repository: <https://github.com/openshift-priv/{github_repo}|*openshift-priv/{github_repo}*>\n"
 
             # Distgit
-            payload += f"Production dist-git repo: <https://pkgs.devel.redhat.com/cgit/containers/{distgit_repo_name}|*{distgit_repo_name}*>\n"
+            payload += f"Production dist-git repo: <{constants.CGIT_URL}/containers/{distgit_repo_name}|*{distgit_repo_name}*>\n"
 
             # Distgit -> Delivery
             payload += pipeline_image_util.distgit_to_delivery(distgit_repo_name, version, variant)
@@ -150,7 +150,7 @@ def pipeline_from_brew(so, brew_name, version):
 
             # Brew
             brew_id = pipeline_image_util.get_brew_id(brew_name)
-            payload += f"Production brew builds: <https://brewweb.engineering.redhat.com/brew/packageinfo?packageID={brew_id}|*{brew_name}*>\n"
+            payload += f"Production brew builds: <{constants.BREW_URL}/packageinfo?packageID={brew_id}|*{brew_name}*>\n"
 
             # Brew -> Delivery
             payload += pipeline_image_util.brew_to_delivery(brew_name, variant)
@@ -259,7 +259,7 @@ def pipeline_from_delivery(so, delivery_repo_name, version):
             payload += pipeline_image_util.brew_to_github(brew_name, version)
 
             # To make the output consistent
-            payload += f"Production brew builds: <https://brewweb.engineering.redhat.com/brew/packageinfo?packageID={brew_id}|*{brew_name}*>\n"
+            payload += f"Production brew builds: <{constants.BREW_URL}/packageinfo?packageID={brew_id}|*{brew_name}*>\n"
 
             # Brew -> CDN
             cdn_repo_name = pipeline_image_util.brew_to_cdn_delivery(brew_name, variant, delivery_repo_name)
@@ -267,7 +267,7 @@ def pipeline_from_delivery(so, delivery_repo_name, version):
 
             # Delivery
             delivery_repo_id = pipeline_image_util.get_delivery_repo_id(delivery_repo_name)
-            payload += f"Delivery (Comet) repo: <https://comet.engineering.redhat.com/containers/repositories/{delivery_repo_id}|*{delivery_repo_name}*>\n\n"
+            payload += f"Delivery (Comet) repo: <{constants.COMET_URL}/{delivery_repo_id}|*{delivery_repo_name}*>\n\n"
         except exceptions.ArtBotExceptions as e:
             payload += "\n"
             payload += f"{e}"

--- a/artbotlib/translation.py
+++ b/artbotlib/translation.py
@@ -1,5 +1,6 @@
 from . import util
 
+
 def translate_names(so, name_type, name, name_type2, major=None, minor=None):
     if name_type not in ["distgit", "dist-git"]:
         so.say(f"Sorry, don't know how to look up a {name_type} yet.")

--- a/functional/test_pipeline_image_names.py
+++ b/functional/test_pipeline_image_names.py
@@ -1,5 +1,5 @@
 import pytest
-from artbotlib import exceptions
+from artbotlib import exceptions, constants
 from artbotlib import pipeline_image_util as img_util
 
 
@@ -82,11 +82,11 @@ def test_distgit_to_brew_3():
 
 def test_distgit_delivery():
     actual = img_util.distgit_to_delivery("clusterresourceoverride-operator", "4.10", "8Base-RHOSE-4.10")
-    expected = """Production brew builds: <https://brewweb.engineering.redhat.com/brew/packageinfo?packageID=73711|*ose-clusterresourceoverride-operator-container*>
+    expected = f"""Production brew builds: <{constants.BREW_URL}/packageinfo?packageID=73711|*ose-clusterresourceoverride-operator-container*>
 Bundle Component: *ose-clusterresourceoverride-operator-metadata-component*
 Bundle Distgit: *clusterresourceoverride-operator-bundle*
-CDN repo: <https://errata.devel.redhat.com/product_versions/1625/cdn_repos/12950|*redhat-openshift4-ose-clusterresourceoverride-rhel8-operator*>
-Delivery (Comet) repo: <https://comet.engineering.redhat.com/containers/repositories/5f6d2a2049dbe0cdd0373f29|*openshift4/ose-clusterresourceoverride-rhel8-operator*>\n\n"""
+CDN repo: <{constants.ERRATA_TOOL_URL}/product_versions/1625/cdn_repos/12950|*redhat-openshift4-ose-clusterresourceoverride-rhel8-operator*>
+Delivery (Comet) repo: <{constants.COMET_URL}/5f6d2a2049dbe0cdd0373f29|*openshift4/ose-clusterresourceoverride-rhel8-operator*>\n\n"""
 
     assert actual == expected
 
@@ -107,9 +107,9 @@ def test_brew_is_available2():
 
 def test_brew_to_github():
     actual = img_util.brew_to_github("ose-clusterresourceoverride-operator-container", "4.10")
-    expected = """Upstream GitHub repository: <https://github.com/openshift/cluster-resource-override-admission-operator|*openshift/cluster-resource-override-admission-operator*>
+    expected = f"""Upstream GitHub repository: <https://github.com/openshift/cluster-resource-override-admission-operator|*openshift/cluster-resource-override-admission-operator*>
 Private GitHub repository: <https://github.com/openshift-priv/cluster-resource-override-admission-operator|*openshift-priv/cluster-resource-override-admission-operator*>
-Production dist-git repo: <https://pkgs.devel.redhat.com/cgit/containers/clusterresourceoverride-operator|*clusterresourceoverride-operator*>
+Production dist-git repo: <{constants.CGIT_URL}/containers/clusterresourceoverride-operator|*clusterresourceoverride-operator*>
 Bundle Component: *ose-clusterresourceoverride-operator-metadata-component*
 Bundle Distgit: *clusterresourceoverride-operator-bundle*\n"""
 
@@ -144,8 +144,8 @@ def test_brew_to_cdn2():
 
 def test_brew_to_delivery():
     actual = img_util.brew_to_delivery("ose-clusterresourceoverride-operator-container", "8Base-RHOSE-4.10")
-    expected = """CDN repo: <https://errata.devel.redhat.com/product_versions/1625/cdn_repos/12950|*redhat-openshift4-ose-clusterresourceoverride-rhel8-operator*>
-Delivery (Comet) repo: <https://comet.engineering.redhat.com/containers/repositories/5f6d2a2049dbe0cdd0373f29|*openshift4/ose-clusterresourceoverride-rhel8-operator*>\n\n"""
+    expected = f"""CDN repo: <{constants.ERRATA_TOOL_URL}/product_versions/1625/cdn_repos/12950|*redhat-openshift4-ose-clusterresourceoverride-rhel8-operator*>
+Delivery (Comet) repo: <{constants.COMET_URL}/5f6d2a2049dbe0cdd0373f29|*openshift4/ose-clusterresourceoverride-rhel8-operator*>\n\n"""
 
     assert actual == expected
 
@@ -229,10 +229,10 @@ def test_get_product_id():
 
 def test_cdn_to_github():
     actual = img_util.cdn_to_github("redhat-openshift4-ose-cli-alt-rhel8", "4.10")
-    expected = """Production brew builds: <https://brewweb.engineering.redhat.com/brew/packageinfo?packageID=79953|*openshift-enterprise-cli-alt-container*>
+    expected = f"""Production brew builds: <{constants.BREW_URL}/packageinfo?packageID=79953|*openshift-enterprise-cli-alt-container*>
 Upstream GitHub repository: <https://github.com/openshift/oc|*openshift/oc*>
 Private GitHub repository: <https://github.com/openshift-priv/oc|*openshift-priv/oc*>
-Production dist-git repo: <https://pkgs.devel.redhat.com/cgit/containers/openshift-enterprise-cli-alt|*openshift-enterprise-cli-alt*>
+Production dist-git repo: <{constants.CGIT_URL}/containers/openshift-enterprise-cli-alt|*openshift-enterprise-cli-alt*>
 Payload tag: *cli-alt* 
 """
     assert actual == expected

--- a/tests/test_brew_list.py
+++ b/tests/test_brew_list.py
@@ -2,13 +2,13 @@ import flexmock
 import pytest
 from unittest.mock import patch, MagicMock
 
-from artbotlib import brew_list
+from artbotlib import brew_list, constants
 
 
 @pytest.mark.parametrize("params, expected",
     [
-        [("4.5",), f"{brew_list.RHCOS_BASE_URL}/rhcos-4.5"],
-        [("4.5", "s390x"), f"{brew_list.RHCOS_BASE_URL}/rhcos-4.5-s390x"],
+        [("4.5",), f"{constants.RHCOS_BASE_URL}/rhcos-4.5"],
+        [("4.5", "s390x"), f"{constants.RHCOS_BASE_URL}/rhcos-4.5-s390x"],
     ]
 )
 def test_rhcos_release_url(params, expected):
@@ -17,9 +17,9 @@ def test_rhcos_release_url(params, expected):
 
 @pytest.mark.parametrize("params, expected",
     [
-        [("4.2", "spam"), f"{brew_list.RHCOS_BASE_URL}/rhcos-4.2/spam"],
-        [("4.5", "eggs"), f"{brew_list.RHCOS_BASE_URL}/rhcos-4.5/eggs/x86_64"],
-        [("4.5", "bacon", "s390x"), f"{brew_list.RHCOS_BASE_URL}/rhcos-4.5-s390x/bacon/s390x"],
+        [("4.2", "spam"), f"{constants.RHCOS_BASE_URL}/rhcos-4.2/spam"],
+        [("4.5", "eggs"), f"{constants.RHCOS_BASE_URL}/rhcos-4.5/eggs/x86_64"],
+        [("4.5", "bacon", "s390x"), f"{constants.RHCOS_BASE_URL}/rhcos-4.5-s390x/bacon/s390x"],
     ]
 )
 def test_rhcos_build_url(params, expected):


### PR DESCRIPTION
Sometimes, you might want to be pinged when a Brew build completes. It might be that you're running a custom job and want to react as soon as it's done to check the build output, open a PR, etc. Or it might be for any other reason that you're impatient and do not want to keep staring at logs or refresh the page.

With this PR, you can ask art-bot to monitor a Brew build continuously and let you know when it's done, and what the final status was. If the build will take more than 12 hours to complete, art-bot will give up and kindly let you know.