### PR TITLE
Add pr in build feature

### DIFF
--- a/artbotlib/constants.py
+++ b/artbotlib/constants.py
@@ -4,6 +4,10 @@ COLOR_MAPS = {
     'Accepted': 'Green',
     'Rejected': 'Red'
 }
+BREW_TASK_STATES = {
+    "Success": "success",
+    "Failure": "failure"
+}
 
 TWELVE_HOURS = 60 * 60 * 12
 
@@ -16,3 +20,5 @@ CGIT_URL = 'https://pkgs.devel.redhat.com/cgit'
 COMET_URL = 'https://comet.engineering.redhat.com/containers/repositories'
 
 ERRATA_TOOL_URL = 'https://errata.devel.redhat.com'
+
+GITHUB_API_OPENSHIFT = "https://api.github.com/repos/openshift"

--- a/artbotlib/pr_in_build.py
+++ b/artbotlib/pr_in_build.py
@@ -217,16 +217,17 @@ class PrInfo:
         }
         url = f"{API}/builds/"
         response = requests.get(url, params=params)
-        return response.json()
+        if response.status_code == 200:
+            return response.json()
 
     def build_from_commit(self, task_state):
         """
         Function to get all the build ids associated with a list of commits
         """
         for commit in self.commits:
-            response = self.get_builds_from_db(commit, task_state)
-            if response["count"] > 0:
-                builds = response["results"]
+            response_data = self.get_builds_from_db(commit, task_state)
+            if response_data and response_data["count"] > 0:
+                builds = response_data["results"]
                 build_ids = [x["build_0_id"] for x in builds]
                 return sorted(build_ids)
 


### PR DESCRIPTION
Feature to check if a PR has been included in a build ([ART-1877](https://issues.redhat.com/browse/ART-1877)).

Workflow:
- Find the commits including and after the merge commit.
- Check each commit from the oldest to newest if has an associated successful build in the database, and report the first successful build.
- If no successful builds, repeat the above steps, but instead look for a failed build, and report the first failed build.
- If no builds have been found, report back saying that a build hasn't started yet for the PR.