### PR TITLE
Add developer interface for art-bot

### DIFF
--- a/art-bot.py
+++ b/art-bot.py
@@ -107,6 +107,145 @@ def incoming_message(client: RTMClient, event: dict):
     pool.apply_async(respond, (client, event))
 
 
+def map_command_to_regex(so, plain_text, user_id):
+    re_snippets = dict(
+        major_minor=r'(?P<major>\d)\.(?P<minor>\d+)',
+        name=r'(?P<name>[\w.-]+)',
+        names=r'(?P<names>[\w.,-]+)',
+        name_type=r'(?P<name_type>dist-?git)',
+        name_type2=r'(?P<name_type2>brew-image|brew-component)',
+        nvr=r'(?P<nvr>[\w.-]+)',
+        wh=r'(which|what)',
+    )
+
+    regex_maps = [
+        # 'regex': regex string
+        # 'flag': flag(s)
+        # 'function': function (without parenthesis)
+
+        {
+            'regex': r"^\W*(hi|hey|hello|howdy|what'?s? up|yo|welcome|greetings)\b",
+            'flag': re.I,
+            'function': greet_user
+        },
+        {
+            'regex': r'^help$',
+            'flag': re.I,
+            'function': show_help
+        },
+
+        # ART releases:
+        {
+            'regex': r'^%(wh)s build of %(name)s is in (?P<release_img>[-.:/#\w]+)$' % re_snippets,
+            'flag': re.I,
+            'function': buildinfo_for_release
+        },
+        {
+            'regex': r'^%(wh)s (?P<data_type>[\w.-]+) are associated with (?P<release_tag>[\w.-]+)$' % re_snippets,
+            'flag': re.I,
+            'function': brew_list.list_component_data_for_release_tag
+        },
+        {
+            'regex': r'^What kernel is used in (?P<release_img>[-.:/#\w]+)$',
+            'flag': re.I,
+            'function': kernel_info
+        },
+
+        # ART build info
+        {
+            'regex': r'^%(wh)s images build in %(major_minor)s$' % re_snippets,
+            'flag': re.I,
+            'function': brew_list.list_images_in_major_minor
+        },
+        {
+            'regex': r'^%(wh)s rpms were used in the latest image builds for %(major_minor)s$' % re_snippets,
+            'flag': re.I,
+            'function': brew_list.list_components_for_major_minor
+        },
+        {
+            'regex': r'^%(wh)s rpms are in image %(nvr)s$' % re_snippets,
+            'flag': re.I,
+            'function': brew_list.list_components_for_image
+        },
+        {
+            'regex': r'^%(wh)s rpms? (?P<rpms>[-\w.,* ]+) (is|are) in image %(nvr)s$' % re_snippets,
+            'flag': re.I,
+            'function': brew_list.specific_rpms_for_image
+        },
+        {
+            'regex': r'^alert ?(if|when|on)? build (?P<build_id>\d+|https\://brewweb.engineering.redhat.com/brew/buildinfo\?buildID=\d+) completes$',
+            'flag': re.I,
+            'function': alert_on_build_complete,
+            'user_id': True
+        },
+
+        # ART advisory info:
+        {
+            'regex': r'^image list.*advisory (?P<advisory_id>\d+)$',
+            'flag': re.I,
+            'function': elliott.image_list
+        },
+
+        # ART config
+        {
+            'regex': r'^where in %(major_minor)s (is|are) the %(names)s (?P<search_type>RPM|package)s? used$' % re_snippets,
+            'flag': re.I,
+            'function': brew_list.list_uses_of_rpms
+        },
+        {
+            'regex': r'^what is the %(name_type2)s for %(name_type)s %(name)s(?: in %(major_minor)s)?$' % re_snippets,
+            'flag': re.I,
+            'function': translate_names
+        },
+
+        # ART pipeline
+        {
+            'regex': r'^.*(image )?pipeline \s*for \s*github \s*(https://)*(github.com/)*(openshift/)*(?P<github_repo>[a-zA-Z0-9-]+)(/|\.git)?\s*( in \s*(?P<version>\d+.\d+))?\s*$',
+            'flag': re.I,
+            'function': pipeline_from_github
+        },
+        {
+            'regex': r'^.*(image )?pipeline \s*for \s*distgit \s*(containers\/){0,1}(?P<distgit_repo_name>[a-zA-Z0-9-]+)( \s*in \s*(?P<version>\d+.\d+))?\s*$',
+            'flag': re.I,
+            'function': pipeline_from_distgit
+        },
+        {
+            'regex': r'^.*(image )?pipeline \s*for \s*package \s*(?P<brew_name>\S*)( \s*in \s*(?P<version>\d+.\d+))?\s*$',
+            'flag': re.I,
+            'function': pipeline_from_brew
+        },
+        {
+            'regex': r'^.*(image )?pipeline \s*for \s*cdn \s*(?P<cdn_repo_name>\S*)( \s*in \s*(?P<version>\d+.\d+))?\s*$',
+            'flag': re.I,
+            'function': pipeline_from_cdn
+        },
+        {
+            'regex': r'^.*(image )?pipeline \s*for \s*image \s*(registry.redhat.io/)*(openshift4/)*(?P<delivery_repo_name>[a-zA-Z0-9-]+)\s*( \s*in \s*(?P<version>\d+.\d+))?\s*$',
+            'flag': re.I,
+            'function': pipeline_from_delivery
+        },
+
+        # Others
+        {
+            'regex': r'^Alert ?(if|when|on)? https://(?P<release_browser>[\w]+).ocp.releases.ci.openshift.org(?P<release_url>[\w/.-]+) ?(stops being blue|fails|is rejected|is red|is accepted|is green)?$',
+            'flag': re.I,
+            'function': nightly_color_status,
+            'user_id': True
+        }
+    ]
+
+    matched_regex = False
+    for r in regex_maps:
+        m = re.match(r['regex'], plain_text, r['flag'])
+        if m:
+            matched_regex = True
+            if r.get('user_id', False):  # if functions need to cc the user
+                r['function'](so, user_id, **m.groupdict())
+            else:
+                r['function'](so, **m.groupdict())
+    if not matched_regex:
+        print(f"'{plain_text}' didwha not match any regexes.\n")
+
 def respond(client: RTMClient, event: dict):
     try:
         data = event
@@ -176,139 +315,7 @@ def respond(client: RTMClient, event: dict):
 
         so.monitoring_say(f"<@{user_id}> asked: {plain_text}")
 
-        re_snippets = dict(
-            major_minor=r'(?P<major>\d)\.(?P<minor>\d+)',
-            name=r'(?P<name>[\w.-]+)',
-            names=r'(?P<names>[\w.,-]+)',
-            name_type=r'(?P<name_type>dist-?git)',
-            name_type2=r'(?P<name_type2>brew-image|brew-component)',
-            nvr=r'(?P<nvr>[\w.-]+)',
-            wh=r'(which|what)',
-        )
-
-        regex_maps = [
-            # 'regex': regex string
-            # 'flag': flag(s)
-            # 'function': function (without parenthesis)
-
-            {
-                'regex': r"^\W*(hi|hey|hello|howdy|what'?s? up|yo|welcome|greetings)\b",
-                'flag': re.I,
-                'function': greet_user
-            },
-            {
-                'regex': r'^help$',
-                'flag': re.I,
-                'function': show_help
-            },
-
-            # ART releases:
-            {
-                'regex': r'^%(wh)s build of %(name)s is in (?P<release_img>[-.:/#\w]+)$' % re_snippets,
-                'flag': re.I,
-                'function': buildinfo_for_release
-            },
-            {
-                'regex': r'^%(wh)s (?P<data_type>[\w.-]+) are associated with (?P<release_tag>[\w.-]+)$' % re_snippets,
-                'flag': re.I,
-                'function': brew_list.list_component_data_for_release_tag
-            },
-            {
-                'regex': r'^What kernel is used in (?P<release_img>[-.:/#\w]+)$',
-                'flag': re.I,
-                'function': kernel_info
-            },
-
-            # ART build info
-            {
-                'regex': r'^%(wh)s images build in %(major_minor)s$' % re_snippets,
-                'flag': re.I,
-                'function': brew_list.list_images_in_major_minor
-            },
-            {
-                'regex': r'^%(wh)s rpms were used in the latest image builds for %(major_minor)s$' % re_snippets,
-                'flag': re.I,
-                'function': brew_list.list_components_for_major_minor
-            },
-            {
-                'regex': r'^%(wh)s rpms are in image %(nvr)s$' % re_snippets,
-                'flag': re.I,
-                'function': brew_list.list_components_for_image
-            },
-            {
-                'regex': r'^%(wh)s rpms? (?P<rpms>[-\w.,* ]+) (is|are) in image %(nvr)s$' % re_snippets,
-                'flag': re.I,
-                'function': brew_list.specific_rpms_for_image
-            },
-            {
-                'regex': r'^alert ?(if|when|on)? build (?P<build_id>\d+|https\://brewweb.engineering.redhat.com/brew/buildinfo\?buildID=\d+) completes$',
-                'flag': re.I,
-                'function': alert_on_build_complete,
-                'user_id': True
-            },
-
-            # ART advisory info:
-            {
-                'regex': r'^image list.*advisory (?P<advisory_id>\d+)$',
-                'flag': re.I,
-                'function': elliott.image_list
-            },
-
-            # ART config
-            {
-                'regex': r'^where in %(major_minor)s (is|are) the %(names)s (?P<search_type>RPM|package)s? used$' % re_snippets,
-                'flag': re.I,
-                'function': brew_list.list_uses_of_rpms
-            },
-            {
-                'regex': r'^what is the %(name_type2)s for %(name_type)s %(name)s(?: in %(major_minor)s)?$' % re_snippets,
-                'flag': re.I,
-                'function': translate_names
-            },
-
-            # ART pipeline
-            {
-                'regex': r'^.*(image )?pipeline \s*for \s*github \s*(https://)*(github.com/)*(openshift/)*(?P<github_repo>[a-zA-Z0-9-]+)(/|\.git)?\s*( in \s*(?P<version>\d+.\d+))?\s*$',
-                'flag': re.I,
-                'function': pipeline_from_github
-            },
-            {
-                'regex': r'^.*(image )?pipeline \s*for \s*distgit \s*(containers\/){0,1}(?P<distgit_repo_name>[a-zA-Z0-9-]+)( \s*in \s*(?P<version>\d+.\d+))?\s*$',
-                'flag': re.I,
-                'function': pipeline_from_distgit
-            },
-            {
-                'regex': r'^.*(image )?pipeline \s*for \s*package \s*(?P<brew_name>\S*)( \s*in \s*(?P<version>\d+.\d+))?\s*$',
-                'flag': re.I,
-                'function': pipeline_from_brew
-            },
-            {
-                'regex': r'^.*(image )?pipeline \s*for \s*cdn \s*(?P<cdn_repo_name>\S*)( \s*in \s*(?P<version>\d+.\d+))?\s*$',
-                'flag': re.I,
-                'function': pipeline_from_cdn
-            },
-            {
-                'regex': r'^.*(image )?pipeline \s*for \s*image \s*(registry.redhat.io/)*(openshift4/)*(?P<delivery_repo_name>[a-zA-Z0-9-]+)\s*( \s*in \s*(?P<version>\d+.\d+))?\s*$',
-                'flag': re.I,
-                'function': pipeline_from_delivery
-            },
-
-            # Others
-            {
-                'regex': r'^Alert ?(if|when|on)? https://(?P<release_browser>[\w]+).ocp.releases.ci.openshift.org(?P<release_url>[\w/.-]+) ?(stops being blue|fails|is rejected|is red|is accepted|is green)?$',
-                'flag': re.I,
-                'function': nightly_color_status,
-                'user_id': True
-            }
-        ]
-
-        for r in regex_maps:
-            m = re.match(r['regex'], plain_text, r['flag'])
-            if m:
-                if r.get('user_id', False):  # if functions need to cc the user
-                    r['function'](so, user_id, **m.groupdict())
-                else:
-                    r['function'](so, **m.groupdict())
+        map_command_to_regex(so, plain_text, user_id)
 
         if not so.said_something:
             so.say("Sorry, I can't help with that yet. Ask 'help' to see what I can do.")
@@ -435,4 +442,23 @@ def run():
 
 
 if __name__ == '__main__':
-    run()
+    if os.environ.get("RUN_ENV") == 'production':
+        run()
+    else:
+        so = SlackOutput(
+            web_client=None,
+            event=None,
+            target_channel_id=None,
+            monitoring_channel_id=None,
+            thread_ts=None,
+            alt_username=None,
+        )
+        print("Welcome to the developer interface for Art-Bot.\n")
+
+        while True:
+            command = input("Enter your command ('exit' to break): ")
+            if command.lower() == "exit":
+                print("Exiting...")
+                break
+
+            map_command_to_regex(so, command, None)

--- a/art-bot.py
+++ b/art-bot.py
@@ -441,14 +441,4 @@ def run():
 
 
 if __name__ == "__main__":
-    if os.environ.get("RUN_ENV") == "production":
-        run()
-    else:
-        so = SlackDeveloperOutput()
-        print("Welcome to the developer interface for Art-Bot.\n")
-        while True:
-            command = input("Enter your command ('exit' to break): ")
-            if command.lower() == "exit":
-                print("Exiting...")
-                break
-            map_command_to_regex(so, command, None)
+    run()

--- a/art-bot.py
+++ b/art-bot.py
@@ -109,142 +109,142 @@ def incoming_message(client: RTMClient, event: dict):
 
 def map_command_to_regex(so, plain_text, user_id):
     re_snippets = dict(
-        major_minor=r'(?P<major>\d)\.(?P<minor>\d+)',
-        name=r'(?P<name>[\w.-]+)',
-        names=r'(?P<names>[\w.,-]+)',
-        name_type=r'(?P<name_type>dist-?git)',
-        name_type2=r'(?P<name_type2>brew-image|brew-component)',
-        nvr=r'(?P<nvr>[\w.-]+)',
-        wh=r'(which|what)',
+        major_minor=r"(?P<major>\d)\.(?P<minor>\d+)",
+        name=r"(?P<name>[\w.-]+)",
+        names=r"(?P<names>[\w.,-]+)",
+        name_type=r"(?P<name_type>dist-?git)",
+        name_type2=r"(?P<name_type2>brew-image|brew-component)",
+        nvr=r"(?P<nvr>[\w.-]+)",
+        wh=r"(which|what)",
     )
 
     regex_maps = [
-        # 'regex': regex string
-        # 'flag': flag(s)
-        # 'function': function (without parenthesis)
+        # "regex": regex string
+        # "flag": flag(s)
+        # "function": function (without parenthesis)
 
         {
-            'regex': r"^\W*(hi|hey|hello|howdy|what'?s? up|yo|welcome|greetings)\b",
-            'flag': re.I,
-            'function': greet_user
+            "regex": r"^\W*(hi|hey|hello|howdy|what'?s? up|yo|welcome|greetings)\b",
+            "flag": re.I,
+            "function": greet_user
         },
         {
-            'regex': r'^help$',
-            'flag': re.I,
-            'function': show_help
+            "regex": r"^help$",
+            "flag": re.I,
+            "function": show_help
         },
 
         # ART releases:
         {
-            'regex': r'^%(wh)s build of %(name)s is in (?P<release_img>[-.:/#\w]+)$' % re_snippets,
-            'flag': re.I,
-            'function': buildinfo_for_release
+            "regex": r"^%(wh)s build of %(name)s is in (?P<release_img>[-.:/#\w]+)$" % re_snippets,
+            "flag": re.I,
+            "function": buildinfo_for_release
         },
         {
-            'regex': r'^%(wh)s (?P<data_type>[\w.-]+) are associated with (?P<release_tag>[\w.-]+)$' % re_snippets,
-            'flag': re.I,
-            'function': brew_list.list_component_data_for_release_tag
+            "regex": r"^%(wh)s (?P<data_type>[\w.-]+) are associated with (?P<release_tag>[\w.-]+)$" % re_snippets,
+            "flag": re.I,
+            "function": brew_list.list_component_data_for_release_tag
         },
         {
-            'regex': r'^What kernel is used in (?P<release_img>[-.:/#\w]+)$',
-            'flag': re.I,
-            'function': kernel_info
+            "regex": r"^What kernel is used in (?P<release_img>[-.:/#\w]+)$",
+            "flag": re.I,
+            "function": kernel_info
         },
 
         # ART build info
         {
-            'regex': r'^%(wh)s images build in %(major_minor)s$' % re_snippets,
-            'flag': re.I,
-            'function': brew_list.list_images_in_major_minor
+            "regex": r"^%(wh)s images build in %(major_minor)s$" % re_snippets,
+            "flag": re.I,
+            "function": brew_list.list_images_in_major_minor
         },
         {
-            'regex': r'^%(wh)s rpms were used in the latest image builds for %(major_minor)s$' % re_snippets,
-            'flag': re.I,
-            'function': brew_list.list_components_for_major_minor
+            "regex": r"^%(wh)s rpms were used in the latest image builds for %(major_minor)s$" % re_snippets,
+            "flag": re.I,
+            "function": brew_list.list_components_for_major_minor
         },
         {
-            'regex': r'^%(wh)s rpms are in image %(nvr)s$' % re_snippets,
-            'flag': re.I,
-            'function': brew_list.list_components_for_image
+            "regex": r"^%(wh)s rpms are in image %(nvr)s$" % re_snippets,
+            "flag": re.I,
+            "function": brew_list.list_components_for_image
         },
         {
-            'regex': r'^%(wh)s rpms? (?P<rpms>[-\w.,* ]+) (is|are) in image %(nvr)s$' % re_snippets,
-            'flag': re.I,
-            'function': brew_list.specific_rpms_for_image
+            "regex": r"^%(wh)s rpms? (?P<rpms>[-\w.,* ]+) (is|are) in image %(nvr)s$" % re_snippets,
+            "flag": re.I,
+            "function": brew_list.specific_rpms_for_image
         },
         {
-            'regex': r'^alert ?(if|when|on)? build (?P<build_id>\d+|https\://brewweb.engineering.redhat.com/brew/buildinfo\?buildID=\d+) completes$',
-            'flag': re.I,
-            'function': alert_on_build_complete,
-            'user_id': True
+            "regex": r"^alert ?(if|when|on)? build (?P<build_id>\d+|https\://brewweb.engineering.redhat.com/brew/buildinfo\?buildID=\d+) completes$",
+            "flag": re.I,
+            "function": alert_on_build_complete,
+            "user_id": True
         },
 
         # ART advisory info:
         {
-            'regex': r'^image list.*advisory (?P<advisory_id>\d+)$',
-            'flag': re.I,
-            'function': elliott.image_list
+            "regex": r"^image list.*advisory (?P<advisory_id>\d+)$",
+            "flag": re.I,
+            "function": elliott.image_list
         },
 
         # ART config
         {
-            'regex': r'^where in %(major_minor)s (is|are) the %(names)s (?P<search_type>RPM|package)s? used$' % re_snippets,
-            'flag': re.I,
-            'function': brew_list.list_uses_of_rpms
+            "regex": r"^where in %(major_minor)s (is|are) the %(names)s (?P<search_type>RPM|package)s? used$" % re_snippets,
+            "flag": re.I,
+            "function": brew_list.list_uses_of_rpms
         },
         {
-            'regex': r'^what is the %(name_type2)s for %(name_type)s %(name)s(?: in %(major_minor)s)?$' % re_snippets,
-            'flag': re.I,
-            'function': translate_names
+            "regex": r"^what is the %(name_type2)s for %(name_type)s %(name)s(?: in %(major_minor)s)?$" % re_snippets,
+            "flag": re.I,
+            "function": translate_names
         },
 
         # ART pipeline
         {
-            'regex': r'^.*(image )?pipeline \s*for \s*github \s*(https://)*(github.com/)*(openshift/)*(?P<github_repo>[a-zA-Z0-9-]+)(/|\.git)?\s*( in \s*(?P<version>\d+.\d+))?\s*$',
-            'flag': re.I,
-            'function': pipeline_from_github
+            "regex": r"^.*(image )?pipeline \s*for \s*github \s*(https://)*(github.com/)*(openshift/)*(?P<github_repo>[a-zA-Z0-9-]+)(/|\.git)?\s*( in \s*(?P<version>\d+.\d+))?\s*$",
+            "flag": re.I,
+            "function": pipeline_from_github
         },
         {
-            'regex': r'^.*(image )?pipeline \s*for \s*distgit \s*(containers\/){0,1}(?P<distgit_repo_name>[a-zA-Z0-9-]+)( \s*in \s*(?P<version>\d+.\d+))?\s*$',
-            'flag': re.I,
-            'function': pipeline_from_distgit
+            "regex": r"^.*(image )?pipeline \s*for \s*distgit \s*(containers\/){0,1}(?P<distgit_repo_name>[a-zA-Z0-9-]+)( \s*in \s*(?P<version>\d+.\d+))?\s*$",
+            "flag": re.I,
+            "function": pipeline_from_distgit
         },
         {
-            'regex': r'^.*(image )?pipeline \s*for \s*package \s*(?P<brew_name>\S*)( \s*in \s*(?P<version>\d+.\d+))?\s*$',
-            'flag': re.I,
-            'function': pipeline_from_brew
+            "regex": r"^.*(image )?pipeline \s*for \s*package \s*(?P<brew_name>\S*)( \s*in \s*(?P<version>\d+.\d+))?\s*$",
+            "flag": re.I,
+            "function": pipeline_from_brew
         },
         {
-            'regex': r'^.*(image )?pipeline \s*for \s*cdn \s*(?P<cdn_repo_name>\S*)( \s*in \s*(?P<version>\d+.\d+))?\s*$',
-            'flag': re.I,
-            'function': pipeline_from_cdn
+            "regex": r"^.*(image )?pipeline \s*for \s*cdn \s*(?P<cdn_repo_name>\S*)( \s*in \s*(?P<version>\d+.\d+))?\s*$",
+            "flag": re.I,
+            "function": pipeline_from_cdn
         },
         {
-            'regex': r'^.*(image )?pipeline \s*for \s*image \s*(registry.redhat.io/)*(openshift4/)*(?P<delivery_repo_name>[a-zA-Z0-9-]+)\s*( \s*in \s*(?P<version>\d+.\d+))?\s*$',
-            'flag': re.I,
-            'function': pipeline_from_delivery
+            "regex": r"^.*(image )?pipeline \s*for \s*image \s*(registry.redhat.io/)*(openshift4/)*(?P<delivery_repo_name>[a-zA-Z0-9-]+)\s*( \s*in \s*(?P<version>\d+.\d+))?\s*$",
+            "flag": re.I,
+            "function": pipeline_from_delivery
         },
 
         # Others
         {
-            'regex': r'^Alert ?(if|when|on)? https://(?P<release_browser>[\w]+).ocp.releases.ci.openshift.org(?P<release_url>[\w/.-]+) ?(stops being blue|fails|is rejected|is red|is accepted|is green)?$',
-            'flag': re.I,
-            'function': nightly_color_status,
-            'user_id': True
+            "regex": r"^Alert ?(if|when|on)? https://(?P<release_browser>[\w]+).ocp.releases.ci.openshift.org(?P<release_url>[\w/.-]+) ?(stops being blue|fails|is rejected|is red|is accepted|is green)?$",
+            "flag": re.I,
+            "function": nightly_color_status,
+            "user_id": True
         }
     ]
 
     matched_regex = False
     for r in regex_maps:
-        m = re.match(r['regex'], plain_text, r['flag'])
+        m = re.match(r["regex"], plain_text, r["flag"])
         if m:
             matched_regex = True
-            if r.get('user_id', False):  # if functions need to cc the user
-                r['function'](so, user_id, **m.groupdict())
+            if r.get("user_id", False):  # if functions need to cc the user
+                r["function"](so, user_id, **m.groupdict())
             else:
-                r['function'](so, **m.groupdict())
-    if not matched_regex:
-        print(f"'{plain_text}' didwha not match any regexes.\n")
+                r["function"](so, **m.groupdict())
+    if os.environ.get("RUN_ENV") == "production" and not matched_regex:
+        print(f"'{plain_text}' did not match any regexes.\n")
 
 def respond(client: RTMClient, event: dict):
     try:
@@ -386,7 +386,6 @@ def consumer_thread(client_id, topic, callback_handler, consumer, durable, user_
 
 @click.command()
 def run():
-    
     try:
         config_file = os.environ.get("ART_BOT_SETTINGS_YAML", f"{os.environ['HOME']}/.config/art-bot/settings.yaml")
         with open(config_file, 'r') as stream:
@@ -441,8 +440,8 @@ def run():
     rtm_client.start()
 
 
-if __name__ == '__main__':
-    if os.environ.get("RUN_ENV") == 'production':
+if __name__ == "__main__":
+    if os.environ.get("RUN_ENV") == "production":
         run()
     else:
         so = SlackOutput(

--- a/art-bot.py
+++ b/art-bot.py
@@ -243,7 +243,7 @@ def map_command_to_regex(so, plain_text, user_id):
                 r["function"](so, user_id, **m.groupdict())
             else:
                 r["function"](so, **m.groupdict())
-    if os.environ.get("RUN_ENV") == "production" and not matched_regex:
+    if os.environ.get("RUN_ENV") != "production" and not matched_regex:
         print(f"'{plain_text}' did not match any regexes.\n")
 
 def respond(client: RTMClient, event: dict):

--- a/art-bot.py
+++ b/art-bot.py
@@ -18,7 +18,7 @@ from artbotlib.buildinfo import buildinfo_for_release, kernel_info, alert_on_bui
 from artbotlib.translation import translate_names
 from artbotlib.util import lookup_channel
 from artbotlib.formatting import extract_plain_text, repeat_in_chunks
-from artbotlib.slack_output import SlackOutput
+from artbotlib.slack_output import SlackOutput, SlackDeveloperOutput
 from artbotlib import brew_list, elliott
 from artbotlib.pipeline_image_names import pipeline_from_distgit, pipeline_from_github, pipeline_from_brew, \
     pipeline_from_cdn, pipeline_from_delivery
@@ -441,23 +441,14 @@ def run():
 
 
 if __name__ == "__main__":
-    if os.environ.get("RUN_ENV") == "production":
-        run()
-    else:
-        so = SlackOutput(
-            web_client=None,
-            event=None,
-            target_channel_id=None,
-            monitoring_channel_id=None,
-            thread_ts=None,
-            alt_username=None,
-        )
+    if os.environ.get("RUN_ENV") != "production":
+        so = SlackDeveloperOutput()
         print("Welcome to the developer interface for Art-Bot.\n")
-
         while True:
             command = input("Enter your command ('exit' to break): ")
             if command.lower() == "exit":
                 print("Exiting...")
                 break
-
             map_command_to_regex(so, command, None)
+    else:
+        run()

--- a/art-bot.py
+++ b/art-bot.py
@@ -441,7 +441,9 @@ def run():
 
 
 if __name__ == "__main__":
-    if os.environ.get("RUN_ENV") != "production":
+    if os.environ.get("RUN_ENV") == "production":
+        run()
+    else:
         so = SlackDeveloperOutput()
         print("Welcome to the developer interface for Art-Bot.\n")
         while True:
@@ -450,5 +452,3 @@ if __name__ == "__main__":
                 print("Exiting...")
                 break
             map_command_to_regex(so, command, None)
-    else:
-        run()

--- a/art-bot.py
+++ b/art-bot.py
@@ -18,7 +18,7 @@ from artbotlib.buildinfo import buildinfo_for_release, kernel_info, alert_on_bui
 from artbotlib.translation import translate_names
 from artbotlib.util import lookup_channel
 from artbotlib.formatting import extract_plain_text, repeat_in_chunks
-from artbotlib.slack_output import SlackOutput, SlackDeveloperOutput
+from artbotlib.slack_output import SlackOutput
 from artbotlib import brew_list, elliott
 from artbotlib.pipeline_image_names import pipeline_from_distgit, pipeline_from_github, pipeline_from_brew, \
     pipeline_from_cdn, pipeline_from_delivery

--- a/art_bot_dev.py
+++ b/art_bot_dev.py
@@ -4,9 +4,9 @@
 
 from artbotlib.slack_output import SlackDeveloperOutput
 
-art_bot = __import__('art-bot')
+art_bot = __import__("art-bot")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     so = SlackDeveloperOutput()
     print("---\nWelcome to the developer interface for Art-Bot.")
     print("To exit, type in 'exit' or use Ctrl-C\n---\n")
@@ -17,4 +17,4 @@ if __name__ == '__main__':
                 break
             art_bot.map_command_to_regex(so, command, None)
     except KeyboardInterrupt:
-        print('Exiting...')
+        print("Exiting...")

--- a/art_bot_dev.py
+++ b/art_bot_dev.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+
+# Script to start the developer interface for art-bot
+
+from artbotlib.slack_output import SlackDeveloperOutput
+
+art_bot = __import__('art-bot')
+
+if __name__ == '__main__':
+    so = SlackDeveloperOutput()
+    print("---\nWelcome to the developer interface for Art-Bot.")
+    print("To exit, type in 'exit' or use Ctrl-C\n---\n")
+    try:
+        while True:
+            command = input("Enter your command: ")
+            if command.lower() == "exit":
+                break
+            art_bot.map_command_to_regex(so, command, None)
+    except KeyboardInterrupt:
+        print('Exiting...')

--- a/artbotlib/kerberos.py
+++ b/artbotlib/kerberos.py
@@ -3,14 +3,14 @@ import os
 
 def do_kinit():
     """
-    Function performs kinit with the already mounted keytab
+    Function performs kinit with the already mounted keytab.
+    This function is executed only in production
     :return: None
     """
-    if os.environ.get("RUN_ENV") == "production":
+    if "OPENSHIFT_BUILD_NAMESPACE" in os.environ:   # check to see if the code is in production environment
         keytab_file = "/tmp/keytab/keytab"
         kinit_request = subprocess.Popen(["kinit", "-kt", keytab_file, "ocp-build/buildvm.openshift.eng.bos.redhat.com@IPA.REDHAT.COM"],
                                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         output, error = kinit_request.communicate()
         if error:
             print(f"Kerberos error: {error}")
-

--- a/artbotlib/kerberos.py
+++ b/artbotlib/kerberos.py
@@ -7,7 +7,7 @@ def do_kinit():
     This function is executed only in production
     :return: None
     """
-    if "OPENSHIFT_BUILD_NAMESPACE" in os.environ:   # check to see if the code is in production environment
+    if "NEEDS_KINIT" in os.environ:   # check to see if the code is in production environment
         keytab_file = "/tmp/keytab/keytab"
         kinit_request = subprocess.Popen(["kinit", "-kt", keytab_file, "ocp-build/buildvm.openshift.eng.bos.redhat.com@IPA.REDHAT.COM"],
                                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/artbotlib/kerberos.py
+++ b/artbotlib/kerberos.py
@@ -6,7 +6,7 @@ def do_kinit():
     Function performs kinit with the already mounted keytab
     :return: None
     """
-    if os.environ.get("RUN_ENV") == 'production':
+    if os.environ.get("RUN_ENV") == "production":
         keytab_file = "/tmp/keytab/keytab"
         kinit_request = subprocess.Popen(["kinit", "-kt", keytab_file, "ocp-build/buildvm.openshift.eng.bos.redhat.com@IPA.REDHAT.COM"],
                                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/artbotlib/kerberos.py
+++ b/artbotlib/kerberos.py
@@ -1,16 +1,16 @@
 import subprocess
-
+import os
 
 def do_kinit():
     """
     Function performs kinit with the already mounted keytab
     :return: None
     """
-
-    keytab_file = "/tmp/keytab/keytab"
-    kinit_request = subprocess.Popen(["kinit", "-kt", keytab_file, "ocp-build/buildvm.openshift.eng.bos.redhat.com@IPA.REDHAT.COM"],
-                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    output, error = kinit_request.communicate()
-    if error:
-        print(f"Kerberos error: {error}")
+    if os.environ.get("RUN_ENV") == 'production':
+        keytab_file = "/tmp/keytab/keytab"
+        kinit_request = subprocess.Popen(["kinit", "-kt", keytab_file, "ocp-build/buildvm.openshift.eng.bos.redhat.com@IPA.REDHAT.COM"],
+                                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output, error = kinit_request.communicate()
+        if error:
+            print(f"Kerberos error: {error}")
 

--- a/artbotlib/slack_output.py
+++ b/artbotlib/slack_output.py
@@ -15,7 +15,7 @@ class SlackOutput:
         self.said_something = False
 
     def say(self, text, **msg_opts):
-        if os.environ.get("RUN_ENV") == 'production':
+        if os.environ.get("RUN_ENV") == "production":
             print(f"Responding back through: {self.target_channel_id}")
             self.said_something = True
             msg = dict(
@@ -50,7 +50,7 @@ class SlackOutput:
         pprint.pprint(r)
 
     def monitoring_say(self, text, **msg_opts):
-        if os.environ.get("RUN_ENV") == 'production':
+        if os.environ.get("RUN_ENV") == "production":
             if not self.monitoring_channel_id:
                 return
             try:
@@ -89,7 +89,7 @@ class SlackOutput:
             traceback.print_exc()
 
     def from_user_mention(self):
-        if os.environ.get("RUN_ENV") == 'production':
+        if os.environ.get("RUN_ENV") == "production":
             return f"<@{self.from_user_id()}>"
         return "@developer"
 

--- a/artbotlib/slack_output.py
+++ b/artbotlib/slack_output.py
@@ -28,7 +28,6 @@ class SlackOutput:
         print(f"response ok: {response.get('ok')}\n")
         pprint.pprint(f"ok: {response.get('message')}")
 
-
     def snippet(self, payload, intro=None, filename=None, filetype=None):
         self.said_something = True
         print(f"Called with payload: {payload}")
@@ -58,7 +57,6 @@ class SlackOutput:
         except Exception:
             print("Error sending information to monitoring channel")
             traceback.print_exc()
-
 
     def monitoring_snippet(self, payload, intro=None, filename=None, filetype=None):
         if not self.monitoring_channel_id:
@@ -93,6 +91,7 @@ def print_payload(text):
     print(text)
     print("---")
 
+
 def print_snippet_payload(payload, intro, filename, filetype):
     print("---")
     print("payload:")
@@ -110,12 +109,13 @@ def print_snippet_payload(payload, intro, filename, filetype):
 
 
 class SlackDeveloperOutput(SlackOutput):
-    def __init__(self, web_client=None, event=None, target_channel_id=None, monitoring_channel_id=None, thread_ts=None, alt_username=None):
+    def __init__(self, web_client=None, event=None, target_channel_id=None, monitoring_channel_id=None, thread_ts=None,
+                 alt_username=None):
         super().__init__(web_client, event, target_channel_id, monitoring_channel_id, thread_ts, alt_username)
+
     def say(self, text, **msg_opts):
         print("so.say:")
         print_payload(text)
-
 
     def monitoring_say(self, text, **msg_opts):
         print("so.monitoring_say:")

--- a/artbotlib/slack_output.py
+++ b/artbotlib/slack_output.py
@@ -15,24 +15,19 @@ class SlackOutput:
         self.said_something = False
 
     def say(self, text, **msg_opts):
-        if os.environ.get("RUN_ENV") == "production":
-            print(f"Responding back through: {self.target_channel_id}")
-            self.said_something = True
-            msg = dict(
-                channel=self.target_channel_id,
-                text=text,
-                thread_ts=self.thread_ts,
-                **self.username_opts,
-            )
-            msg.update(msg_opts)
-            response = self.web_client.chat_postMessage(**msg)
-            print(f"response ok: {response.get('ok')}\n")
-            pprint.pprint(f"ok: {response.get('message')}")
-        else:
-            print("so.say:")
-            print("---")
-            print(text)
-            print("---")
+        print(f"Responding back through: {self.target_channel_id}")
+        self.said_something = True
+        msg = dict(
+            channel=self.target_channel_id,
+            text=text,
+            thread_ts=self.thread_ts,
+            **self.username_opts,
+        )
+        msg.update(msg_opts)
+        response = self.web_client.chat_postMessage(**msg)
+        print(f"response ok: {response.get('ok')}\n")
+        pprint.pprint(f"ok: {response.get('message')}")
+
 
     def snippet(self, payload, intro=None, filename=None, filetype=None):
         self.said_something = True
@@ -50,25 +45,20 @@ class SlackOutput:
         pprint.pprint(r)
 
     def monitoring_say(self, text, **msg_opts):
-        if os.environ.get("RUN_ENV") == "production":
-            if not self.monitoring_channel_id:
-                return
-            try:
-                msg = dict(
-                    channel=self.monitoring_channel_id,
-                    text=text,
-                    **self.username_opts,
-                )
-                msg.update(msg_opts)
-                self.web_client.chat_postMessage(**msg)
-            except Exception:
-                print("Error sending information to monitoring channel")
-                traceback.print_exc()
-        else:
-            print("so.monitoring_say:")
-            print("---")
-            print(text)
-            print("---")
+        if not self.monitoring_channel_id:
+            return
+        try:
+            msg = dict(
+                channel=self.monitoring_channel_id,
+                text=text,
+                **self.username_opts,
+            )
+            msg.update(msg_opts)
+            self.web_client.chat_postMessage(**msg)
+        except Exception:
+            print("Error sending information to monitoring channel")
+            traceback.print_exc()
+
 
     def monitoring_snippet(self, payload, intro=None, filename=None, filetype=None):
         if not self.monitoring_channel_id:
@@ -89,12 +79,61 @@ class SlackOutput:
             traceback.print_exc()
 
     def from_user_mention(self):
-        if os.environ.get("RUN_ENV") == "production":
-            return f"<@{self.from_user_id()}>"
-        return "@developer"
+        return f"<@{self.from_user_id()}>"
 
     def from_user_id(self):
         return self.event.get("user", None)
 
     def from_channel(self):
         return self.event.get("channel", None)
+
+
+def print_payload(text):
+    print("---")
+    print(text)
+    print("---")
+
+def print_snippet_payload(payload, intro, filename, filetype):
+    print("---")
+    print("payload:")
+    print(payload)
+    if intro:
+        print("intro:")
+        print(intro)
+    if filename:
+        print("filename:")
+        print(filetype)
+    if filetype:
+        print("filetype:")
+        print(filetype)
+    print("---")
+
+
+class SlackDeveloperOutput(SlackOutput):
+    def __init__(self, web_client=None, event=None, target_channel_id=None, monitoring_channel_id=None, thread_ts=None, alt_username=None):
+        super().__init__(web_client, event, target_channel_id, monitoring_channel_id, thread_ts, alt_username)
+    def say(self, text, **msg_opts):
+        print("so.say:")
+        print_payload(text)
+
+
+    def monitoring_say(self, text, **msg_opts):
+        print("so.monitoring_say:")
+        print_payload(text)
+
+    def snippet(self, payload, intro=None, filename=None, filetype=None):
+        print("so.snippet:")
+        print_snippet_payload(payload, intro, filename, filetype)
+
+    def monitoring_snippet(self, payload, intro=None, filename=None, filetype=None):
+        print("so.monitoring_snippet:")
+        print_snippet_payload(payload, intro, filename, filetype)
+
+    def from_user_mention(self):
+        return "@developer"
+
+    def from_user_id(self):
+        return "@developer"
+
+    def from_channel(self):
+        return "developer_channel"


### PR DESCRIPTION
Preparing art-bot for migrating from classic slack app to the latest slack app. Currently slack is sending responses to both production and development environments as its using [RTM](https://api.slack.com/rtm). When we migrate to socket mode, slack will randomly send the responses to [any of the connections](https://api.slack.com/apis/connections/socket-implement#connections). Therefore developing using `@art-bot-dev` will no longer be possible.

It was proposed during team sync that a developer command line interface could remedy the situation, as we can test the regexes using that and in production, we'll connect to the actual slack object.

To start, run `./art_bot_dev`

Sample interface:
```
Welcome to the developer interface for Art-Bot.

Enter your command ('exit' to break): what's up
'what's up' did not match any regexes.

Enter your command ('exit' to break): hello
so.say:
---
Hi, @developer
---
Enter your command ('exit' to break): exit
Exiting...
```


Need to set NEEDS_KINIT in production after merge.

